### PR TITLE
Fix default exports typed with React.FC docgen

### DIFF
--- a/src/__tests__/__fixtures__/DefaultExportComponentFC.tsx
+++ b/src/__tests__/__fixtures__/DefaultExportComponentFC.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+interface DefaultExportComponentFCProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: "blue" | "green";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+const DefaultExportComponentFC: React.FC<DefaultExportComponentFCProps> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+export default DefaultExportComponentFC;

--- a/src/__tests__/__fixtures__/DefaultExportComponentFC2.tsx
+++ b/src/__tests__/__fixtures__/DefaultExportComponentFC2.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+interface DefaultExportComponentFC2Props {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: "blue" | "green";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+const DefaultExportComponentFC2 = (
+  props: React.PropsWithChildren<DefaultExportComponentFC2Props>
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+export default DefaultExportComponentFC2;

--- a/src/__tests__/__fixtures__/DefaultExportComponentFC3.tsx
+++ b/src/__tests__/__fixtures__/DefaultExportComponentFC3.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+interface DefaultExportComponentFC3Props {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: "blue" | "green";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+export const DefaultExportComponentFC3: React.FC<DefaultExportComponentFC3Props> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+export default DefaultExportComponentFC3;

--- a/src/__tests__/__fixtures__/DefaultExportForwardRef.tsx
+++ b/src/__tests__/__fixtures__/DefaultExportForwardRef.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+interface DefaultExportForwardRefProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: "blue" | "green";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+const DefaultExportForwardRef = React.forwardRef(
+  (props: React.PropsWithChildren<DefaultExportForwardRefProps>, ref) => (
+    <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+      {props.counter}
+      {props.children}
+    </button>
+  )
+);
+
+export default DefaultExportForwardRef;

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -209,6 +209,51 @@ try {
 catch (__react_docgen_typescript_loader_error) { }"
 `;
 
+exports[`component fixture DefaultExportForwardRef.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface DefaultExportForwardRefProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: \\"blue\\" | \\"green\\";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+const DefaultExportForwardRef = React.forwardRef(
+  (props: React.PropsWithChildren<DefaultExportForwardRefProps>, ref) => (
+    <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+      {props.counter}
+      {props.children}
+    </button>
+  )
+);
+
+export default DefaultExportForwardRef;
+
+try {
+    // @ts-ignore
+    DefaultExportForwardRef.displayName = \\"DefaultExportForwardRef\\";
+    // @ts-ignore
+    DefaultExportForwardRef.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultExportForwardRef\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": null, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": null, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"boolean\\" } }, \\"ref\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"ref\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"Ref<unknown>\\" } }, \\"key\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"key\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"Key\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
 exports[`component fixture DefaultPropValue.tsx has code block generated 1`] = `
 "import * as React from \\"react\\";
 

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -74,6 +74,141 @@ try {
 catch (__react_docgen_typescript_loader_error) { }"
 `;
 
+exports[`component fixture DefaultExportComponentFC.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface DefaultExportComponentFCProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: \\"blue\\" | \\"green\\";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+const DefaultExportComponentFC: React.FC<DefaultExportComponentFCProps> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+export default DefaultExportComponentFC;
+
+try {
+    // @ts-ignore
+    DefaultExportComponentFC.displayName = \\"DefaultExportComponentFC\\";
+    // @ts-ignore
+    DefaultExportComponentFC.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultExportComponentFC\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": null, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": null, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture DefaultExportComponentFC2.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface DefaultExportComponentFC2Props {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: \\"blue\\" | \\"green\\";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+const DefaultExportComponentFC2 = (
+  props: React.PropsWithChildren<DefaultExportComponentFC2Props>
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+export default DefaultExportComponentFC2;
+
+try {
+    // @ts-ignore
+    DefaultExportComponentFC2.displayName = \\"DefaultExportComponentFC2\\";
+    // @ts-ignore
+    DefaultExportComponentFC2.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultExportComponentFC2\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": null, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": null, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture DefaultExportComponentFC3.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface DefaultExportComponentFC3Props {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: \\"blue\\" | \\"green\\";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+export const DefaultExportComponentFC3: React.FC<DefaultExportComponentFC3Props> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+export default DefaultExportComponentFC3;
+
+try {
+    // @ts-ignore
+    DefaultExportComponentFC3.displayName = \\"DefaultExportComponentFC3\\";
+    // @ts-ignore
+    DefaultExportComponentFC3.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultExportComponentFC3\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": null, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": null, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
 exports[`component fixture DefaultPropValue.tsx has code block generated 1`] = `
 "import * as React from \\"react\\";
 

--- a/src/getIdentifier.ts
+++ b/src/getIdentifier.ts
@@ -1,9 +1,30 @@
 /* eslint-disable import/prefer-default-export */
 import { ComponentDoc } from "react-docgen-typescript";
 
+// From: https://github.com/styleguidist/react-docgen-typescript/blob/287e7012843cb26fed8f4bd8ee24e462c25a1414/src/parser.ts#L308-L317
+const defaultComponentTypes = [
+  "__function",
+  "StatelessComponent",
+  "Stateless",
+  "StyledComponentClass",
+  "StyledComponent",
+  "FunctionComponent",
+  "ForwardRefExoticComponent",
+  "MemoExoticComponent",
+];
+
 export function getIdentifier(d: ComponentDoc): string {
   const name = d.expression?.getName();
-  return ["default", "__function", "FunctionComponent"].includes(name as string) || !name
+
+  // In those cases, react-docgen-typescript can not find a runtime name because a default export is used.
+  // We fall back to the displayName, although this doesn't work for every case.
+  //
+  // It works in cases where the file name matches the variable name used for the default export:
+  //
+  // src/component/MyComponent.tsx
+  // const MyComponent: React.FC<Props> = (props) => <></>;
+  // export default MyComponent;
+  return ["default", ...defaultComponentTypes].includes(name as string) || !name
     ? d.displayName
     : name;
 }

--- a/src/getIdentifier.ts
+++ b/src/getIdentifier.ts
@@ -3,7 +3,7 @@ import { ComponentDoc } from "react-docgen-typescript";
 
 export function getIdentifier(d: ComponentDoc): string {
   const name = d.expression?.getName();
-  return ["default", "__function"].includes(name as string) || !name
+  return ["default", "__function", "FunctionComponent"].includes(name as string) || !name
     ? d.displayName
     : name;
 }


### PR DESCRIPTION
Fixes https://github.com/storybookjs/storybook/issues/21898
Fixes https://github.com/storybookjs/storybook/issues/21801

I added `FunctionComponent` to the list of expression that need to get the identifier name from displayName.
I guess this has recently changed upstream.

I also added some more tests, to make sure other ways to write default exports doesn't regress.
