### PR TITLE
Do not skip processing modules restored from cache

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -204,12 +204,6 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
 
             const nameForCondition = module.nameForCondition() || "";
 
-            // Ignore already built modules for webpack 5
-            if (!compilation.builtModules.has(module)) {
-              debugExclude(`Ignoring un-built module: ${nameForCondition}`);
-              return;
-            }
-
             // Ignore external modules
             // eslint-disable-next-line
             // @ts-ignore: Webpack 4 type


### PR DESCRIPTION
Inclusion in `compilation.builtModules` (which is under documented) does not indicate a module has already been built, usage within plugins included in `webpack` confirms this.

The current behaviour lead to an incomplete Storybook build (missing documentation) when our custom cache plugin was enabled. The changes in this PR are already applied internally via a patch.

## Examples

### `lib/Compilation.js`

By default, modules are only added to `compilation.builtModules` when the module itself indicates it needs to be built (modules served from the cache via `compiler.cache.hooks.get` do not need to be built).

https://github.com/webpack/webpack/blob/34e2561addb0f65a7a6fb0ce7ae1aea4cd1d599f/lib/Compilation.js#L1387-L1405

### `lib/optimize/ModuleConcatenationPlugin.js`

Concatenated modules are only marked as built when an included module is included in `compilation.builtModules`.

https://github.com/webpack/webpack/blob/34e2561addb0f65a7a6fb0ce7ae1aea4cd1d599f/lib/optimize/ModuleConcatenationPlugin.js#L439-L442

### `lib/stats/DefaultStatsFactoryPlugin.js`

`compilation.builtModules` is one of the indicators used to determine if a given module was served from the cache, the other being `compilation.codeGeneratedModules`.

https://github.com/webpack/webpack/blob/34e2561addb0f65a7a6fb0ce7ae1aea4cd1d599f/lib/stats/DefaultStatsFactoryPlugin.js#L1097-L1116

## `compiler.cache.hooks.get` Examples

- https://github.com/webpack/webpack/blob/34e2561addb0f65a7a6fb0ce7ae1aea4cd1d599f/lib/cache/MemoryCachePlugin.js#L30
- https://github.com/webpack/webpack/blob/34e2561addb0f65a7a6fb0ce7ae1aea4cd1d599f/lib/cache/IdleFileCachePlugin.js#L66
- https://github.com/webpack/webpack/blob/34e2561addb0f65a7a6fb0ce7ae1aea4cd1d599f/lib/cache/MemoryWithGcCachePlugin.js#L93